### PR TITLE
Remove omitempty on Component/ComponentGroup's properties

### DIFF
--- a/component.go
+++ b/component.go
@@ -2,11 +2,11 @@ package statuspagesdk
 
 type Component struct {
 	Name               string `json:"name"`
-	Description        string `json:"description,omitempty"`
+	Description        string `json:"description"`
 	GroupID            string `json:"group_id,omitempty"`
-	Showcase           bool   `json:"showcase,omitempty"`
+	Showcase           bool   `json:"showcase"`
 	Status             string `json:"status,omitempty"`
-	OnlyShowIfDegraded bool   `json:"only_show_if_degraded,omitempty"`
+	OnlyShowIfDegraded bool   `json:"only_show_if_degraded"`
 }
 
 type ComponentFull struct {

--- a/component_group.go
+++ b/component_group.go
@@ -2,7 +2,7 @@ package statuspagesdk
 
 type ComponentGroup struct {
 	Name        string   `json:"name"`
-	Description string   `json:"description,omitempty"`
+	Description string   `json:"description"`
 	Components  []string `json:"components,omitempty"`
 }
 


### PR DESCRIPTION
Go's `omitempty` annotation removes a field from JSON if it has an empty value.  Therefore, the SDK cannot update boolean property to false, because it is also treated as a empty-value in boolean.

The `terraform-provider-statuspage` currently cannot update boolean property such as showcase and only_show_if_degraded to false.  The empty value of `description` (empty string `""`) is also allowed in API.