### PR TITLE
Require the metric_base_uri parameter for Datadog metrics providers

### DIFF
--- a/metrics_provider.go
+++ b/metrics_provider.go
@@ -67,6 +67,9 @@ func (mp *MetricsProvider) validate() error {
 		if *mp.ApplicationKey == "" {
 			return fmt.Errorf("parameter application_key is required for Datadog Metrics Provider")
 		}
+		if *mp.MetricBaseUri == "" {
+			return fmt.Errorf("parameter metric_base_uri is required for Datadog Metrics Provider")
+		}
 	}
 
 	return nil


### PR DESCRIPTION
This check is needed to enforce the requirement for the Datadog metrics provider in Atlassian Statuspage.
Without it, the resource creation will result in a 422 failure on resource creation.

The error reporting should also be improved, since debugging these 422 responses in Terraform is impossible without replicating the calls in `curl`, but that will be a separate PR, or I will open an issue if I cannot figure it out.